### PR TITLE
Fix exception when decoded value is too large by doubling buffer

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,12 +32,6 @@ def test_decode_error():
     assert exc_info.value.args[0] == 'Error occur executing xdelta3: XD3_INVALID_INPUT'
 
 
-def test_no_delta():
-    with pytest.raises(xdelta3.NoDeltaFound) as exc_info:
-        xdelta3.encode(b'hello', b'goodbye')
-    assert exc_info.value.args[0] == 'No delta found shorter than the input value'
-
-
 def test_different_compression():
     all_ascii = (string.ascii_letters + string.digits).encode()
     v1 = all_ascii * 1000
@@ -55,6 +49,14 @@ def test_different_compression():
 def test_version():
     # can't easily test output as capsys doesn't capture output of print_version
     xdelta3.print_version()
+
+
+def test_huge_output():
+    b1 = b''
+    b2 = b't' * 10000  # 10K same characters
+    d = xdelta3.encode(b1, b2)
+    assert len(d) < 100  # 0 bytes + very small delta = big output
+    assert xdelta3.decode(b1, d) == b2
 
 
 def test_readme():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,7 @@ def test_long_random():
 def test_decode_error():
     with pytest.raises(xdelta3.XDeltaError) as exc_info:
         xdelta3.decode(expected_delta, value_one)
-    assert exc_info.value.args[0] == 'Error occur executing xdelta3: XD3_INVALID_INPUT'
+    assert exc_info.value.args[0] == 'Error occurred executing xdelta3: XD3_INVALID_INPUT'
 
 
 def test_different_compression():

--- a/xdelta3/main.py
+++ b/xdelta3/main.py
@@ -2,12 +2,11 @@ import sys
 from enum import IntEnum
 
 import _xdelta3
-from _xdelta3 import NoDeltaFound, XDeltaError  # noqa
+from _xdelta3 import XDeltaError  # noqa
 
 from .version import VERSION
 
 __all__ = [
-    'NoDeltaFound',
     'XDeltaError',
     'Flags',
     'encode',


### PR DESCRIPTION
1. No need for the test files. There's a much simpler reproduction, which I included in the tests.
1. Removed the test for NoDelta found. This will be covered in the logic for doubling the buffer. This changes the API a bit, since now you are free to get a larger delta than the second argument. However, I think that this is, in fact, the correct behavior from an API standpoint. Imagine you write your code, test it with reasonable inputs, everything works. One day your production code breaks, because of some edge case. I think cases of larger delta than the input should be handled by the client code, if it's actually an issue. Otherwise you will just surprise them badly.
1. The above actually removes the need for the NoDelta exception, so it's removed as well.
1. `sizeof(int) - 4` is horrible, but I'm too lazy ATM to implement the correct solution, which is to check that you didn't overflow the int when left shifting in those 2 places. The error handling logic will be more complicated as well.
1. The sprintf had a buffer overflow vulnerability. Fixed by using snprintf. I agree this can get a string truncated, but is much better than it was before.